### PR TITLE
Fix problem with environment variables

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,11 +26,11 @@ RUN useradd -M cozy \
 
 
 # Need ENV VARS:
-ENV NODE_ENV production \
-    COUCH_HOST couchdb \
-    COUCH_PORT 5984 \
-    INDEXER_HOST dataindexer \
-    INDEXER_PORT 9102
+ENV NODE_ENV=production \
+	COUCH_HOST=couchdb \
+	COUCH_PORT=5984 \
+	INDEXER_HOST=dataindexer \
+	INDEXER_PORT=9102
 
 # Expose port
 EXPOSE 9002 9104


### PR DESCRIPTION
With the previous version, NODE_ENV variable content was production COUCH_HOST couchdb COUCH_PORT 5984 INDEXER_HOST dataindexer INDEXER_PORT 9102.

Another possibility would be to remove completely these definition and define them in the `docker-compose.yml` file.

```
configuration-data:
    build: cozy-conf

couchdb-data:
    build: cozy-couchdb-data

couchdb:
    build: cozy-couchdb
    hostname: couchdb
    restart: always
    volumes_from:
        - couchdb-data
        - configuration-data

data-indexer:
    build: cozy-data-indexer
    hostname: dataindexer
    restart: always
    volumes_from:
        - configuration-data

controller:
    build: cozy-controller
    restart: always
    environment:
        NODE_ENV: production
        COUCH_HOST: couchdb
        COUCH_PORT: 5984
        INDEXER_HOST: dataindexer
        INDEXER_PORT: 9102
    links:
        - couchdb
        - data-indexer
    volumes_from:
        - configuration-data
        - data-indexer
    ports:
        - "127.0.0.1:9104:9104"
```

Note that I remove the logs from the volumes since this is not really portable.  And you can access them through something like

```
docker exec couchdb tail -f /var/log/couchdb/couch.log
```

See https://github.com/woshilapin/dot/tree/master/docker/cozy for a complete solution.
